### PR TITLE
Store web hooks in DynamoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+### Project
+/dynamodb/
+
+
 ### Python.gitignore
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN mkdir -p /opt/app
 WORKDIR /opt/app
 
 COPY . .
-RUN python setup.py install
 
 EXPOSE 5000
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Most external services allow data to be shared via [webhooks][webhook]. The DEC
 provides an endpoint that accepts such webhooks and stores their payload in a
 database.
 
+While the application is set up in a way that allows different deployments
+(e.g. via Docker), the initial implementation is made with [AWS Lambda][lambda]
+and [DynamoDB] in mind.
+
 ## Development
 
 To extend the service or customize it, either fork or clone this repository.
@@ -37,6 +41,18 @@ pip install -r requirements.txt
 
 After that, you can hack away and make any changes you require to make the code
 work for you. 😊
+
+### DynamoDB
+
+The default backend for DEC is Amazon's [DynamoDB]. For development and
+testing, you can run an instance locally. First, go to the following page and
+download the package from your nearest region:
+
+[Setting Up DynamoDB Local](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html#DynamoDBLocal.DownloadingAndRunning)
+
+Then, extract its contents into the `dynamodb` directory. Once you've done
+this, you can use the script `start_dynamodb.sh` in `scripts` to run the
+server.
 
 ### Running the server
 
@@ -66,5 +82,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+[dynamodb]: https://aws.amazon.com/dynamodb/
+[lambda]: https://aws.amazon.com/lambda/
 [virtualenv]: http://python-guide-pt-br.readthedocs.io/en/latest/dev/virtualenvs/
 [webhook]: https://en.wikipedia.org/wiki/Webhook

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Then, extract its contents into the `dynamodb` directory. Once you've done
 this, you can use the script `start_dynamodb.sh` in `scripts` to run the
 server.
 
+**Note:** When starting the database for the first time, make sure to run
+`create_table.sh` in a different terminal as well.
+
 ### Running the server
 
 During development, you can run the server by simply starting the app:

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,4 +1,23 @@
-app:
-  build: .
-  environment:
-    FLASK_ENV: development
+version: '3'
+services:
+  app:
+    build: .
+    environment:
+      FLASK_ENV: test
+    links:
+      - dynamodb
+  aws:
+    image: cgswong/aws
+    entrypoint: sh
+    environment:
+      - AWS_ACCESS_KEY_ID=foo
+      - AWS_SECRET_ACCESS_KEY=bar
+      - AWS_DEFAULT_REGION=eu-west-1
+    links:
+      - dynamodb
+    volumes:
+      - ./scripts:/scripts
+  dynamodb:
+    image: deangiberson/aws-dynamodb-local
+    volumes:
+      - ./dynamodb:/var/dynamodb_local

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -4,6 +4,16 @@
     - service: app
       name: "Lint code"
       command: flake8
-    - service: app
-      name: "Test dec"
-      command: python setup.py test
+    - type: serial
+      name: "Test app"
+      steps:
+        - name: "Create table"
+          service: aws
+          command: "/scripts/wait-for.sh dynamodb:8000 -t 60 -- aws dynamodb create-table --endpoint-url=http://dynamodb:8000 --attribute-definitions=AttributeName=dec_id,AttributeType=S --table-name=automatiqa-dec --key-schema=AttributeName=dec_id,KeyType=HASH --provisioned-throughput=ReadCapacityUnits=1,WriteCapacityUnits=1"
+        - name: "List tables"
+          service: aws
+          command: "/scripts/wait-for.sh dynamodb:8000 -t 60 -- aws dynamodb list-tables --endpoint-url=http://dynamodb:8000"
+        - name: "Run tests"
+          service: app
+          entrypoint: sh
+          command: "./scripts/wait-for.sh dynamodb:8000 -t 60 -- python setup.py test"

--- a/dec/api.py
+++ b/dec/api.py
@@ -5,7 +5,14 @@ This module implements the API that our Data Entry Clerk provides. The API
 consists of two endpoints: one health check for monitoring or load balancing,
 and the endpoint that processes and stores webhooks.
 """
-from flask import jsonify
+from datetime import datetime
+from uuid import uuid4
+
+import boto3
+import pytz
+from botocore.exceptions import ClientError
+from decimal import Decimal
+from flask import jsonify, request, json
 
 from dec import app
 
@@ -22,3 +29,36 @@ def status():
     :return: The status encoded as a JSON object and HTTP 200
     """
     return jsonify({"status": "ok"}), 200
+
+
+@app.route("/incoming", methods=["POST"])
+def process():
+    """
+    Process an incoming webhook.
+
+    Incoming webhooks contain data that should be stored in a database. The
+    data is extracted by parsing the request body, and written to the database.
+    If both operations are successful, HTTP 200 is returned. Otherwise, HTTP
+    400 or 500 are returned, depending on the cause of the failure.
+
+    :return: HTTP 200 if successful, HTTP 400 or 500 in case of an error
+    """
+    data = json.loads(request.data, parse_float=Decimal)
+
+    if not data:
+        return jsonify({"errors": ["Empty request"]}), 400
+
+    data["dec_id"] = str(uuid4())
+    data["dec_created_at"] = str(datetime.utcnow().replace(tzinfo=pytz.utc))
+
+    dynamodb = boto3.resource('dynamodb',
+                              endpoint_url=app.config['DYNAMODB_ENDPOINT'])
+    table = dynamodb.Table(app.config['DYNAMODB_TABLE'])
+
+    try:
+        table.put_item(Item=data)
+    except ClientError as e:
+        print(str(e))
+        return jsonify({"errors": [str(e)]}), 500
+
+    return jsonify(data), 200

--- a/dec/api.py
+++ b/dec/api.py
@@ -51,8 +51,13 @@ def process():
     data["dec_id"] = str(uuid4())
     data["dec_created_at"] = str(datetime.utcnow().replace(tzinfo=pytz.utc))
 
-    dynamodb = boto3.resource('dynamodb',
-                              endpoint_url=app.config['DYNAMODB_ENDPOINT'])
+    dynamodb = boto3.resource(
+        'dynamodb',
+        endpoint_url=app.config['DYNAMODB_ENDPOINT'],
+        aws_access_key_id=app.config['AWS_ACCESS_KEY_ID'],
+        aws_secret_access_key=app.config['AWS_SECRET_ACCESS_KEY'],
+        region_name=app.config['AWS_REGION']
+    )
     table = dynamodb.Table(app.config['DYNAMODB_TABLE'])
 
     try:

--- a/dec/config/default.py
+++ b/dec/config/default.py
@@ -9,11 +9,15 @@ of environment variables.
 # Enable debug mode for Flask
 DEBUG = True
 
+# Leave empty to use default region
+AWS_REGION = None
+
+# CAUTION! Never commit your credentials to version control.
+AWS_ACCESS_KEY_ID = None
+AWS_SECRET_ACCESS_KEY = None
+
 # Leave empty to use default DynamoDB endpoint in current region
 DYNAMODB_ENDPOINT = None
-
-# Leave empty to use default region
-DYNAMODB_REGION = None
 
 # Overwrite this in environment specific configuration files
 DYNAMODB_TABLE = "automatiqa-dec"

--- a/dec/config/default.py
+++ b/dec/config/default.py
@@ -8,3 +8,12 @@ of environment variables.
 
 # Enable debug mode for Flask
 DEBUG = True
+
+# Leave empty to use default DynamoDB endpoint in current region
+DYNAMODB_ENDPOINT = None
+
+# Leave empty to use default region
+DYNAMODB_REGION = None
+
+# Overwrite this in environment specific configuration files
+DYNAMODB_TABLE = "automatiqa-dec"

--- a/dec/config/development.py
+++ b/dec/config/development.py
@@ -4,3 +4,6 @@ Development configuration.
 The configuration for local development ensures that the application uses local
 or temporary resources, so that new features can be tested in isolation.
 """
+
+# Use DynamoDB Local for development. See README for more information.
+DYNAMODB_ENDPOINT = "http://localhost:8000"

--- a/dec/config/test.py
+++ b/dec/config/test.py
@@ -1,0 +1,17 @@
+"""
+Test configuration.
+
+Tests are usually executed in Docker, so we configure the endpoint by its link
+name. Make sure the hostname resolves to either localhost or a Docker container
+running DynamoDB Local.
+"""
+
+# Must be set, but aren't used.
+AWS_ACCESS_KEY_ID = "foo"
+AWS_SECRET_ACCESS_KEY = "bar"
+
+# Must be set, but isn't used.
+AWS_REGION = "eu-west-1"
+
+# Leave empty to use default DynamoDB endpoint in current region
+DYNAMODB_ENDPOINT = "http://dynamodb:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ Flask==0.12.2
 itsdangerous==0.24
 Jinja2==2.9.6
 MarkupSafe==1.0
+pytz==2017.2
+simplejson==3.11.1
 Werkzeug==0.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,15 @@
+boto3==1.4.5
+botocore==1.5.92
 click==6.7
+docutils==0.14
 Flask==0.12.2
 itsdangerous==0.24
 Jinja2==2.9.6
+jmespath==0.9.3
 MarkupSafe==1.0
+python-dateutil==2.6.1
 pytz==2017.2
+s3transfer==0.1.10
 simplejson==3.11.1
+six==1.10.0
 Werkzeug==0.12.2

--- a/scripts/create_table.sh
+++ b/scripts/create_table.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+tables=$(aws dynamodb list-tables --endpoint-url http://localhost:8000)
+
+if ! echo "$tables" | grep "automatiqa-dec"
+then
+    aws dynamodb create-table \
+    --endpoint-url "http://localhost:8000" \
+    --attribute-definitions "AttributeName=id,AttributeType=S" \
+    --table-name "automatiqa-dec" \
+    --key-schema "AttributeName=id,KeyType=HASH" \
+    --provisioned-throughput "ReadCapacityUnits=1,WriteCapacityUnits=1"
+fi

--- a/scripts/create_table.sh
+++ b/scripts/create_table.sh
@@ -6,8 +6,8 @@ if ! echo "$tables" | grep "automatiqa-dec"
 then
     aws dynamodb create-table \
     --endpoint-url "http://localhost:8000" \
-    --attribute-definitions "AttributeName=id,AttributeType=S" \
+    --attribute-definitions "AttributeName=dec_id,AttributeType=S" \
     --table-name "automatiqa-dec" \
-    --key-schema "AttributeName=id,KeyType=HASH" \
+    --key-schema "AttributeName=dec_id,KeyType=HASH" \
     --provisioned-throughput "ReadCapacityUnits=1,WriteCapacityUnits=1"
 fi

--- a/scripts/start_dynamodb.sh
+++ b/scripts/start_dynamodb.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+current_dir="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+cd "$current_dir"/../dynamodb
+java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -sharedDb

--- a/scripts/wait-for.sh
+++ b/scripts/wait-for.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Source: https://github.com/Eficode/wait-for
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  command="$*"
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ -n "$command" ] ; then
+        exec $command
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'flask',
+        'pytz',
+        'simplejson'
     ],
     setup_requires=['pytest-runner'],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     packages=['dec'],
     include_package_data=True,
     install_requires=[
+        'boto3',
         'flask',
         'pytz',
         'simplejson'

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,7 +16,7 @@ def test_status_ok(app):
     Under normal conditions, the status check is supposed to return HTTP 200
     OK.
 
-    :param app: The Flask dec
+    :param app: The Flask app
     """
     response = app.test_client().get('/')
     body = json.loads(response.get_data())
@@ -26,6 +26,14 @@ def test_status_ok(app):
 
 
 def test_process(app):
+    """
+    Test the endpoint processing incoming webhooks.
+
+    The endpoint parses the request and stores its payload in a DynamoDB
+    table.
+
+    :param app: The Flask app
+    """
     data = {
         "name": "Data Entry Clerk",
         "message": "Running tests",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,8 @@ this module ensure that the endpoints process requests correctly.
 """
 import json
 
+import time
+
 
 def test_status_ok(app):
     """
@@ -21,3 +23,20 @@ def test_status_ok(app):
 
     assert '200 OK' == response.status
     assert 'ok' == body['status']
+
+
+def test_process(app):
+    data = {
+        "name": "Data Entry Clerk",
+        "message": "Running tests",
+        "timestamp": time.time()
+    }
+
+    response = app.test_client().post('/incoming',
+                                      data=json.dumps(data),
+                                      content_type='application/json')
+    assert '200 OK' == response.status
+
+    body = json.loads(response.get_data())
+    assert 'dec_id' in body
+    assert 'dec_created_at' in body


### PR DESCRIPTION
The endpoint to store incoming webhooks in DynamoDB has been created. Before saving an item, a "dec_id" and a timestamp is added. While not necessarily mandatory, it does make processing a little bit easier in our experience.

To enable users to develop and test their code with confidence, we include instructions how to set up and run a local instance of DynamoDB. The database and its libraries need to be downloaded, and can be placed in this new directory.